### PR TITLE
Fix apollo vulnerability

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   context: authMiddleware,
+  cache: "bounded"
 });
 
 app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
assigned a bounded cache to the apollo server to fix a vulnerability that allowed DOS attacks